### PR TITLE
Allow using ESP32 ADC again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ if (DEFINED ESP_PLATFORM)
     # idf component
     idf_component_register(
         # SRC_DIRS src
-        INCLUDE_DIRS src 
-        REQUIRES bt esp_common freertos hal log nvs_flash driver
+        INCLUDE_DIRS src
+        REQUIRES bt esp_adc esp_common freertos hal log nvs_flash driver
     )
 
     target_compile_options(${COMPONENT_LIB} INTERFACE -DESP32_CMAKE=1 -Wno-error -Wno-format -fpermissive)

--- a/src/AudioConfig.h
+++ b/src/AudioConfig.h
@@ -90,7 +90,7 @@ typedef WiFiClient WiFiClientSecure;
  */
  
 #ifndef USE_AUDIO_LOGGING 
-#  define USE_AUDIO_LOGGING true
+#  define USE_AUDIO_LOGGING false
 #endif
 
 #ifndef LOG_LEVEL 

--- a/src/AudioConfig.h
+++ b/src/AudioConfig.h
@@ -46,7 +46,7 @@ typedef WiFiClient WiFiClientSecure;
 // E.g when using the Espressif IDF. Use cmake for the necesseary defines
 #elif defined(ESP32_CMAKE)
 #  define ESP32
-#  include "AudioTools/AudioRuntime.h"
+#  include "AudioTools/CoreAudio/AudioRuntime.h"
 #  include "AudioTools/AudioLibs/Desktop/NoArduino.h"
 #else 
 #  include "AudioTools/AudioLibs/Desktop/NoArduino.h"
@@ -278,7 +278,7 @@ typedef WiFiClient WiFiClientSecure;
 #  define USE_INT24_FROM_INT
 #endif
 
-#define USE_ANALOG
+// #define USE_ANALOG
 #define USE_I2S
 #define USE_PDM_RX
 

--- a/src/AudioConfig.h
+++ b/src/AudioConfig.h
@@ -278,7 +278,7 @@ typedef WiFiClient WiFiClientSecure;
 #  define USE_INT24_FROM_INT
 #endif
 
-// #define USE_ANALOG
+#define USE_ANALOG
 #define USE_I2S
 #define USE_PDM_RX
 

--- a/src/AudioTools/AudioLibs/Desktop/NoArduino.h
+++ b/src/AudioTools/AudioLibs/Desktop/NoArduino.h
@@ -200,6 +200,7 @@ inline long map(long x, long in_min, long in_max, long out_min, long out_max) {
 
 } // namespace
 
+#if defined(IS_MIN_DESKTOP)
 #if defined(ESP32) 
 #include "driver/gpio.h"
 /// e.g. for AudioActions
@@ -230,6 +231,7 @@ void pinMode(int pin, int mode) {
 	}
 }
 
+#endif
 #endif
 
 //using namespace audio_tools;

--- a/src/AudioTools/CoreAudio/AudioI2S/I2SESP32.h
+++ b/src/AudioTools/CoreAudio/AudioI2S/I2SESP32.h
@@ -185,6 +185,11 @@ class I2SDriverESP32 {
     this->i2s_num = (i2s_port_t)cfg.port_no;
     setChannels(cfg.channels);
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+    mclk_multiple = cfg.bits_per_sample == 24 ? I2S_MCLK_MULTIPLE_384 :
+                                                I2S_MCLK_MULTIPLE_DEFAULT;
+#endif
+
     i2s_config_t i2s_config_new = {
         .mode = toMode(cfg),
         .sample_rate = (eps32_i2s_sample_rate_type)cfg.sample_rate,
@@ -198,7 +203,7 @@ class I2SDriverESP32 {
         .tx_desc_auto_clear = cfg.auto_clear,
 #if ESP_IDF_VERSION_MAJOR >= 4
         .fixed_mclk = (int)(cfg.fixed_mclk > 0 ? cfg.fixed_mclk : 0),
-        .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
+        .mclk_multiple = mclk_multiple, /*I2S_MCLK_MULTIPLE_DEFAULT,*/
         .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
 #endif
     };

--- a/src/AudioTools/CoreAudio/AudioI2S/I2SESP32V1.h
+++ b/src/AudioTools/CoreAudio/AudioI2S/I2SESP32V1.h
@@ -37,10 +37,8 @@ class I2SDriverESP32V1 {
       if (info.equalsExSampleRate(cfg)) {
         cfg.sample_rate = info.sample_rate;
         LOGI("i2s_set_sample_rates: %d", (int)info.sample_rate);
-        bool res;
-        res = getDriver(cfg).changeBitsPerSample(cfg, rx_chan, tx_chan);
-        res |= getDriver(cfg).changeSampleRate(cfg, rx_chan, tx_chan);
-        return res;
+        return getDriver(cfg).changeBitsPerSample(cfg, rx_chan, tx_chan) &&
+                getDriver(cfg).changeSampleRate(cfg, rx_chan, tx_chan);
       }
     } else {
       LOGE("not started");

--- a/src/AudioTools/CoreAudio/AudioI2S/I2SESP32V1.h
+++ b/src/AudioTools/CoreAudio/AudioI2S/I2SESP32V1.h
@@ -34,12 +34,10 @@ class I2SDriverESP32V1 {
     // nothing to do
     if (is_started) {
       if (info.equals(cfg)) return true;
-      if (info.equalsExSampleRate(cfg)) {
-        cfg.sample_rate = info.sample_rate;
-        LOGI("i2s_set_sample_rates: %d", (int)info.sample_rate);
-        return getDriver(cfg).changeBitsPerSample(cfg, rx_chan, tx_chan) &&
-                getDriver(cfg).changeSampleRate(cfg, rx_chan, tx_chan);
-      }
+      cfg.sample_rate = info.sample_rate;
+      LOGI("i2s_set_sample_rates: %d", (int)info.sample_rate);
+      return getDriver(cfg).changeBitsPerSample(cfg, rx_chan, tx_chan) &&
+              getDriver(cfg).changeSampleRate(cfg, rx_chan, tx_chan);
     } else {
       LOGE("not started");
     }

--- a/src/AudioTools/CoreAudio/AudioLogger.h
+++ b/src/AudioTools/CoreAudio/AudioLogger.h
@@ -246,14 +246,14 @@ protected:
 #else
 
 // Switch off logging
-#define LOGD(...) 
-#define LOGI(...) 
-#define LOGW(...) 
-#define LOGE(...) 
-#define TRACED()
-#define TRACEI()
-#define TRACEW()
-#define TRACEE()
+#define LOGD(...) {}
+#define LOGI(...) {}
+#define LOGW(...) {}
+#define LOGE(...) {}
+#define TRACED() {}
+#define TRACEI() {}
+#define TRACEW() {}
+#define TRACEE() {}
 
 #endif
 


### PR DESCRIPTION
This was disabled to fix a compilation error in 19af3072a93d6a79d4175523fcea7355c6cf7aaf, but it looks like compilation is fine as long as `esp_adc` is added to the component dependency list.